### PR TITLE
Fix git line ending conversions

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Treat all test data files as binary to prevent line ending conversions on Windows, macOS or linux
+**/delta.vcdiff binary
+**/source binary
+**/target binary


### PR DESCRIPTION
- This PR adds a .gitattributes file to configure Git line ending handling for test data files. The change prevents Git from performing automatic line ending conversions on binary test files that could be corrupted by such transformations.
- Tests were failing on windows due git line endings, related PR -> https://github.com/ably/delta-codec-dotnet/pull/14/files